### PR TITLE
Changed explicit customDomain non-null check to truthy check (#85)

### DIFF
--- a/js/src/launchAsync.ts
+++ b/js/src/launchAsync.ts
@@ -134,7 +134,7 @@ export function launchAsync(token: string, subdomain: string, content: Content, 
             });
         }
 
-        const domain = options.customDomain !== null ? options.customDomain : 'https://learningtools.onenote.com/learningtoolsapp/cognitive/';
+        const domain = options.customDomain ? options.customDomain : 'https://learningtools.onenote.com/learningtoolsapp/cognitive/';
         let src = domain + 'reader?exitCallback=ImmersiveReader-Exit';
         if (options.uiLang) {
             src += '&omkt=' + options.uiLang;


### PR DESCRIPTION
The reason is that customDomain defaults to undefined if not explicitly set to a value which causes the value to be used.

Solves #85 