### PR TITLE
Reset the immersive reader state on errors (#88)

### DIFF
--- a/js/src/launchAsync.ts
+++ b/js/src/launchAsync.ts
@@ -109,10 +109,10 @@ export function launchAsync(token: string, subdomain: string, content: Content, 
                 resetTimeout();
                 resolve(iframeContainer);
             } else if (e.data === 'ImmersiveReader-TokenExpired') {
-                resetTimeout();
+                reset();
                 reject({ code: ErrorCode.TokenExpired, message: 'The access token supplied is expired.' });
             } else if (e.data === 'ImmersiveReader-Throttled') {
-                resetTimeout();
+                reset();
                 reject({ code: ErrorCode.Throttled, message: 'You have exceeded your quota.' });
             }
         };
@@ -120,6 +120,7 @@ export function launchAsync(token: string, subdomain: string, content: Content, 
 
         // Reject the promise if the Immersive Reader page fails to load.
         timeoutId = window.setTimeout((): void => {
+            reset();
             reject({ code: ErrorCode.Timeout, message: `Page failed to load after timeout (${options.timeout} ms)` });
         }, options.timeout);
 


### PR DESCRIPTION
In order to prevent users getting stuck with a white page if something goes wrong.

This solves #88 (which also contains the reproduction steps).